### PR TITLE
use docker-compose "--scale worker=N" to scale workers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,8 @@ MURDOCK_QUEUES="default-first default"
 MURDOCK_JOBS=4
 
 # this specifies the size of the tmpfs that murdock will build on, *per worker*.
-# currently, keep this >=1.5g.
-MURDOCK_BUILD_TMPFS_GIGS=1.5
+# currently, keep this >=2g.
+MURDOCK_BUILD_TMPFS_GIGS=2
 
 # this currently needs to be 8 gigs to be useful.
 # increasing this improves performance, but not much.

--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,19 @@ MURDOCK_HOSTNAME=unnamed-worker
 # (use something else to do basic tests first)
 MURDOCK_QUEUES="default-first default"
 
-# by default, this compose file will execute MURDOCK_WORKERS murdock jobs in
-# parallel, each calling make with #"-j ${MURDOCK_JOBS}".
+# by default, this compose file will execute only one murdock job, 
+# calling make with #"-j ${MURDOCK_JOBS}".
 #
-# NOTE: if you increase the number of workers, you'll also need to increase
-# `MURDOCK_BUILD_TMPFS_GIGS`!
-MURDOCK_WORKERS=4
+# If you have the RAM, scale up to about one worker per physical core, using
+# `docker-compose up -d --scale worker=N`.
+#
+# If that would exhaust physical RAM, scale less but use a higher `MURDOCK_JOBS`
+# number.
 MURDOCK_JOBS=4
+
+# this specifies the size of the tmpfs that murdock will build on, *per worker*.
+# currently, keep this >=1.5g.
+MURDOCK_BUILD_TMPFS_GIGS=1.5
 
 # this currently needs to be 8 gigs to be useful.
 # increasing this improves performance, but not much.
@@ -22,10 +28,6 @@ MURDOCK_CCACHE_MAXSIZE_GIGS=8
 # so in order to fill gigabytes of cache, set this to 1000000 per 4 gig.
 # or, keep at 0 (limited only by file size)
 MURDOCK_CCACHE_MAX_FILES=0
-
-# this specifies the size of the tmpfs that murdock will build on.
-# set this to 1-1.5gig per worker.
-MURDOCK_BUILD_TMPFS_GIGS=4
 
 # configure the remote disque/redis host names
 MURDOCK_REMOTE_DISQUE_HOST_PORT=localhost:7711

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ for RIOT.
 
 The stack will include the following containers:
 
-- one container using `riot/murdock-worker` that runs the dwq job runner
+- one or more container(s) using `riot/murdock-worker` that runs the dwq job runner
 - one ssh_bridge that connects via ssh to the murdock control node and provides
   access to its disque and redis instances
 - a cache keep-alive node, which mounts the same tmpfs cache volume as the worker

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The stack will include the following containers:
 ## Murdock Worker requirements
 
 - _at least_ four fast cores
-- 1.5GB RAM per worker + 8GB RAM for ccache
+- 2GB RAM per worker + 8GB RAM for ccache
 
 ## Prerequisites
 
@@ -33,6 +33,7 @@ The stack will include the following containers:
   - ensure correct permissions: `chown root:root ssh/*`
 - Copy `.env.example` to `.env`
 - Edit `.env`. Change _at least_ the hostname.
+
 - For Murdock ci-staging, comment these values (so defaults are used):
 
         MURDOCK_REMOTE_DISQUE_HOST_PORT=localhost:7711
@@ -42,4 +43,5 @@ The stack will include the following containers:
 
 If the worker is dedicated to being a Murdock worker, one worker per physical
 core each running 4 jobs ensures the CPUs keep busy.
-If RAM is an issue, go down on workers to one per two cores.
+If RAM is an issue, go down on workers to one per two cores, possible increasing
+`MURDOCK_JOBS`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     user: "999"
     entrypoint:
       - /murdock-worker.sh
-    command: dwqw --name ${MURDOCK_HOSTNAME} --queues ${MURDOCK_HOSTNAME} ${MURDOCK_QUEUES:-defaultx} --jobs ${MURDOCK_WORKERS:-2} --verbose
+    command: dwqw --name ${MURDOCK_HOSTNAME} --queues ${MURDOCK_HOSTNAME} ${MURDOCK_QUEUES:-defaultx} --jobs 1 --verbose
 
     restart: unless-stopped
     labels:


### PR DESCRIPTION
This makes each job run in it's own (network) namespace, which is an effective workaround for https://github.com/RIOT-OS/RIOT/issues/18103.

As per-worker tmpfs are used, increase that size to 2g(up from 1.5g) by default.