### PR TITLE
ssh_bridge: fixup ssh key permissions

### DIFF
--- a/scripts/ssh_bridge.sh
+++ b/scripts/ssh_bridge.sh
@@ -3,6 +3,7 @@
 mkdir -p /root/.ssh
 cp /ssh/* /root/.ssh
 chown root:root /root/.ssh
+chmod 0600 /root/.ssh/id_*
 
 exec /usr/bin/autossh \
       -M 0 -C -N -o ServerAliveInterval=60 -o ServerAliveCountMax=2 \


### PR DESCRIPTION
Fixes this permissions error when just copying over the keyfile:

```
ssh_bridge_1       | Load key "/root/.ssh/id_rsa_murdock-slave": bad permissions
ssh_bridge_1       | murdock-slave@ci-staging.riot-os.org: Permission denied (publickey,keyboard-interactive).
ssh_bridge_1       | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
ssh_bridge_1       | @         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
ssh_bridge_1       | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
ssh_bridge_1       | Permissions 0644 for '/root/.ssh/id_rsa_murdock-slave' are too open.
ssh_bridge_1       | It is required that your private key files are NOT accessible by others.
ssh_bridge_1       | This private key will be ignored.
ssh_bridge_1       | Load key "/root/.ssh/id_rsa_murdock-slave": bad permissions
ssh_bridge_1       | murdock-slave@ci-staging.riot-os.org: Permission denied (publickey,keyboard-interactive).
```