### PR TITLE
use redis for ccache

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ The stack will include the following containers:
 - one or more container(s) using `riot/murdock-worker` that runs the dwq job runner
 - one ssh_bridge that connects via ssh to the murdock control node and provides
   access to its disque and redis instances
-- a cache keep-alive node, which mounts the same tmpfs cache volume as the worker
-  container. this allows the tmpfs to survive worker restarts
+- one redis instance acting as ccache storage backend
 - a watchtower instance keeping all containers up-to-date.
 
 ## Murdock Worker requirements

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,17 +6,14 @@ services:
     tmpfs:
        - /tmp:exec,size=${MURDOCK_BUILD_TMPFS_GIGS}g,rw
     volumes:
-      - ccache:/cache/.ccache
-      - gitcache:/cache/.gitcache
+      - cache:/cache
+      - redis-ccache:/cache/redis
       - ./scripts/murdock-worker.sh:/murdock-worker.sh
     environment:
       - CCACHE="ccache"
       - CCACHE_DIR=/cache/.ccache
-      - CCACHE_MAXSIZE=${MURDOCK_CCACHE_MAXSIZE_GIGS:-8}G
-      - CCACHE_COMPRESS=true
-      # each file takes at least 4kb, so this needs to match the max size
-      # default to `0` (unlimited)
-      - CCACHE_MAX_FILES=${MURDOCK_CCACHE_MAX_FILES:-0}
+      - CCACHE_REMOTE_ONLY=1
+      - CCACHE_REMOTE_STORAGE=redis+unix:/cache/redis/redis-ccache.sock
       - GIT_CACHE_DIR=/cache/.gitcache
       - MURDOCK_HOSTNAME=${MURDOCK_HOSTNAME}
       - MURDOCK_REDIS_HOST=ssh_bridge
@@ -28,6 +25,17 @@ services:
     command: dwqw --name ${MURDOCK_HOSTNAME} --queues ${MURDOCK_HOSTNAME} ${MURDOCK_QUEUES:-defaultx} --jobs 1 --verbose
 
     restart: unless-stopped
+    labels:
+      - com.centurylinklabs.watchtower.scope=murdock-worker-${MURDOCK_HOSTNAME}
+
+  redis-ccache:
+    image: redis
+    environment:
+      - MURDOCK_CCACHE_MAXSIZE_GIGS=${MURDOCK_CCACHE_MAXSIZE_GIGS:-8}
+    command: redis-server --maxmemory ${MURDOCK_CCACHE_MAXSIZE_GIGS}G --maxmemory-policy allkeys-lru --unixsocket /data/redis-ccache.sock
+    restart: unless-stopped
+    volumes:
+      - redis-ccache:/data
     labels:
       - com.centurylinklabs.watchtower.scope=murdock-worker-${MURDOCK_HOSTNAME}
 
@@ -47,21 +55,6 @@ services:
     labels:
       - com.centurylinklabs.watchtower.scope=murdock-worker-${MURDOCK_HOSTNAME}
 
-  cache-keepalive:
-      # this is used to keep the cache volume alive during restarts of the other
-      # service containers (e.g., when docker compose recreates them after a pull.)
-      # if the last container using a tmpfs volume unmounts it, the tmpfs
-      # contents are gone. So, use a dummy container that's just using the
-      # volume
-      # Also, fixup cache folder permissions.
-      image: alpine:latest
-      init: true
-      volumes:
-        - ccache:/cache/.ccache
-        - gitcache:/cache/.gitcache
-      command: sh -c 'trap "exit" INT TERM KILL; chown 999 /cache/.ccache /cache/.gitcache ; while true; do sleep 1 ; done'
-      restart: unless-stopped
-
   watchtower:
     image: containrrr/watchtower
     volumes:
@@ -73,9 +66,5 @@ services:
     restart: unless-stopped
 
 volumes:
-  ccache:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
-      o: exec,rw,noatime,size=${MURDOCK_CCACHE_MAXSIZE_GIGS:-8}g
-  gitcache:
+  cache:
+  redis-ccache:


### PR DESCRIPTION
This drops the ccache tmpfs in favour of a local redis instance.

~~**depends on https://github.com/RIOT-OS/riotdocker/pull/216**, so marked as draft.~~ (216 has been merged)

It's hard to get concrete numbers on performance changes. I noticed e.g., breeze getting lower avg build times when it was up for a while. at that point, the ccache is usually full (80%-95%), and the "cleanups" value shows a couple thousand cleanups. My gut feeling is that ccache doesn't handle cache cleanups too well.

I modified beast to run this PR (and RIOT-OS/riotdocker/pull/216), let's watch it for a while.

 **update** beast and breeze have been running this for two days now, and show consistently low job avg / high throughput. Before, breeze would degrade after a while. (beast didn't run that long lately).